### PR TITLE
Add isito quitquitquit command to init job

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 8.1.2
+version: 8.1.3
 appVersion: 22.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -1,5 +1,6 @@
 {{ $isClusterInitEnabled := and (eq (len .Values.conf.join) 0) (not (index .Values.conf `single-node`)) }}
 {{ $isDatabaseProvisioningEnabled := .Values.init.provisioning.enabled }}
+{{ $isIstioEnabled := .Values.init.istio.enabled }}
 {{- if or $isClusterInitEnabled $isDatabaseProvisioningEnabled }}
   {{ template "cockroachdb.tlsValidation" . }}
 kind: Job
@@ -94,6 +95,15 @@ spec:
           - /bin/bash
           - -c
           - >-
+            {{- if $isIstioEnabled }}
+              istio() {
+                trap "curl --max-time 2 -s -f -XPOST http://127.0.0.1:15000/quitquitquit" EXIT
+                while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done;
+                sleep 2;
+              }
+              istio;
+            {{- end }}
+            
             {{- if $isClusterInitEnabled }}
               initCluster() {
                 while true; do

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -423,6 +423,10 @@ init:
     #       # https://www.cockroachlabs.com/docs/stable/create-schedule-for-backup.html#schedule-options
     #       options: [first_run = 'now']
 
+# enable istio to wait for the proxy to be ready and to quit when done.
+  istio:
+    enabled: false
+
 
 # Whether to run securely using TLS certificates.
 tls:


### PR DESCRIPTION
Make it possible to use Istio. The init job pod never completes if istio is deployed. Therefore we need to wait until the envoy proxy is ready and after everything is done we need to tell the proxy to quit.