### PR TITLE
Add tls config possibilities

### DIFF
--- a/cockroachdb/Chart.yaml
+++ b/cockroachdb/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 name: cockroachdb
 home: https://www.cockroachlabs.com
-version: 8.1.2
+version: 8.1.4
 appVersion: 22.1.3
 description: CockroachDB is a scalable, survivable, strongly-consistent SQL database.
 icon: https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/media/cockroach_db.png

--- a/cockroachdb/templates/serviceMonitor.yaml
+++ b/cockroachdb/templates/serviceMonitor.yaml
@@ -48,4 +48,11 @@ spec:
     {{- if $serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ $serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- if $serviceMonitor.scheme }}
+    scheme: {{ $serviceMonitor.scheme }}
+    {{- end }}
+    {{- if $serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{ $serviceMonitor.tlsConfig | toYaml }}
+    {{- end }}
 {{- end }}

--- a/cockroachdb/values.yaml
+++ b/cockroachdb/values.yaml
@@ -324,6 +324,9 @@ serviceMonitor:
   # scrapeTimeout: 10s
   # Limits the ServiceMonitor to the current namespace if set to `true`.
   namespaced: false
+  tlsConfig: {}
+  # Set a different scheme than http
+  # scheme: https
 
 # CockroachDB's data persistence.
 # If neither `persistentVolume` nor `hostPath` is used, then data will be


### PR DESCRIPTION
Add the possibility to configure `tlsConfig` for the ServiceMonitor like in [this upstream PR](https://github.com/cockroachdb/helm-charts/pull/181). Also make it possible to configure the `scheme` of the endpoint.