### PR TITLE
Add missing linebreak that caused the init pod to fail

### DIFF
--- a/cockroachdb/templates/job.init.yaml
+++ b/cockroachdb/templates/job.init.yaml
@@ -101,6 +101,7 @@ spec:
                 while ! curl -s -f http://127.0.0.1:15020/healthz/ready; do sleep 1; done;
                 sleep 2;
               }
+
               istio;
             {{- end }}
             


### PR DESCRIPTION
Add missing linebreak that caused the init pod to fail.